### PR TITLE
Remove default Dependency

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,95 +7,97 @@ creative = {}
 creative.get_translator = S
 
 local function update_sfinv(name)
-	minetest.after(0, function()
-		local player = minetest.get_player_by_name(name)
-		if player then
-			if sfinv.get_page(player):sub(1, 9) == "creative:" then
-				sfinv.set_page(player, sfinv.get_homepage_name(player))
-			else
-				sfinv.set_player_inventory_formspec(player)
-			end
-		end
-	end)
+  minetest.after(0, function()
+    local player = minetest.get_player_by_name(name)
+    if player then
+      if sfinv.get_page(player):sub(1, 9) == "creative:" then
+        sfinv.set_page(player, sfinv.get_homepage_name(player))
+      else
+        sfinv.set_player_inventory_formspec(player)
+      end
+    end
+  end)
 end
 
 minetest.register_privilege("creative", {
-	description = S("Allow player to use creative inventory"),
-	give_to_singleplayer = false,
-	give_to_admin = false,
-	on_grant = update_sfinv,
-	on_revoke = update_sfinv,
+  description = S("Allow player to use creative inventory"),
+  give_to_singleplayer = false,
+  give_to_admin = false,
+  on_grant = update_sfinv,
+  on_revoke = update_sfinv,
 })
 
 -- Override the engine's creative mode function
 local old_is_creative_enabled = minetest.is_creative_enabled
 
 function minetest.is_creative_enabled(name)
-	if name == "" then
-		return old_is_creative_enabled(name)
-	end
-	return minetest.check_player_privs(name, {creative = true}) or
-		old_is_creative_enabled(name)
+  if name == "" then
+    return old_is_creative_enabled(name)
+  end
+  return minetest.check_player_privs(name, {creative = true}) or
+    old_is_creative_enabled(name)
 end
 
 -- For backwards compatibility:
 function creative.is_enabled_for(name)
-	return minetest.is_creative_enabled(name)
+  return minetest.is_creative_enabled(name)
 end
 
 dofile(minetest.get_modpath("creative") .. "/inventory.lua")
 
 if minetest.is_creative_enabled("") then
-	-- Dig time is modified according to difference (leveldiff) between tool
-	-- 'maxlevel' and node 'level'. Digtime is divided by the larger of
-	-- leveldiff and 1.
-	-- To speed up digging in creative, hand 'maxlevel' and 'digtime' have been
-	-- increased such that nodes of differing levels have an insignificant
-	-- effect on digtime.
-	local digtime = 42
-	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
+  -- Dig time is modified according to difference (leveldiff) between tool
+  -- 'maxlevel' and node 'level'. Digtime is divided by the larger of
+  -- leveldiff and 1.
+  -- To speed up digging in creative, hand 'maxlevel' and 'digtime' have been
+  -- increased such that nodes of differing levels have an insignificant
+  -- effect on digtime.
+  local digtime = 42
+  local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
 
-	-- Override the hand tool
-	minetest.override_item("", {
-		range = 10,
-		tool_capabilities = {
-			full_punch_interval = 0.5,
-			max_drop_level = 3,
-			groupcaps = {
-				crumbly = caps,
-				cracky  = caps,
-				snappy  = caps,
-				choppy  = caps,
-				oddly_breakable_by_hand = caps,
-				-- dig_immediate group doesn't use value 1. Value 3 is instant dig
-				dig_immediate =
-					{times = {[2] = digtime, [3] = 0}, uses = 0, maxlevel = 256},
-			},
-			damage_groups = {fleshy = 10},
-		}
-	})
+  minetest.after(0, function()
+    -- Override the hand tool
+    minetest.override_item("", {
+      range = 10,
+      tool_capabilities = {
+        full_punch_interval = 0.5,
+        max_drop_level = 3,
+        groupcaps = {
+          crumbly = caps,
+          cracky  = caps,
+          snappy  = caps,
+          choppy  = caps,
+          oddly_breakable_by_hand = caps,
+          -- dig_immediate group doesn't use value 1. Value 3 is instant dig
+          dig_immediate =
+            {times = {[2] = digtime, [3] = 0}, uses = 0, maxlevel = 256},
+        },
+        damage_groups = {fleshy = 10},
+      }
+    })
+  end)
 end
 
 -- Unlimited node placement
 minetest.register_on_placenode(function(pos, newnode, placer, oldnode, itemstack)
-	if placer and placer:is_player() then
-		return minetest.is_creative_enabled(placer:get_player_name())
-	end
+  if placer and placer:is_player() then
+    return minetest.is_creative_enabled(placer:get_player_name())
+  end
 end)
 
 -- Don't pick up if the item is already in the inventory
 local old_handle_node_drops = minetest.handle_node_drops
 function minetest.handle_node_drops(pos, drops, digger)
-	if not digger or not digger:is_player() or
-		not minetest.is_creative_enabled(digger:get_player_name()) then
-		return old_handle_node_drops(pos, drops, digger)
-	end
-	local inv = digger:get_inventory()
-	if inv then
-		for _, item in ipairs(drops) do
-			if not inv:contains_item("main", item, true) then
-				inv:add_item("main", item)
-			end
-		end
-	end
+  if not digger or not digger:is_player() or
+    not minetest.is_creative_enabled(digger:get_player_name()) then
+    return old_handle_node_drops(pos, drops, digger)
+  end
+  local inv = digger:get_inventory()
+  if inv then
+    for _, item in ipairs(drops) do
+      if not inv:contains_item("main", item, true) then
+        inv:add_item("main", item)
+      end
+    end
+  end
 end

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = creative
 description = Minetest Game mod: creative
-depends = default, sfinv
+depends = sfinv


### PR DESCRIPTION
I'm not sure if `creative` is being updated or accepting changes (since the repo says "Read Only"). But pull requests are enabled so I thought I would give this a shot.

It is useful outside of Minetest Game & since Minetest Game is currently frozen I think `creative` should be more standalone. The mod configuration claims it is dependent on `default`. But I didn't find any references to `default` grepping the code & it works in games where `default` is not installed. So this pull request simply removes the `default` dependency.

I also put in a [request to add mod to Minetest Mods](https://github.com/minetest-mods/minetest-mods.github.io/issues/121) in case this repo is not being updated.

**Edit:** I have been informed that the dependency on `default` is to prevent changes to hand tool from being overwritten. I have added another commit that calls `minetest.after` to get around this dependency & attempt to prevent other mods from overwriting changes to hand as well.